### PR TITLE
Add remindly.care domain with SSL support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,85 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Repository Overview
+
+Remindly is a desktop-first, caregiver-aware reminder system for seniors. The monorepo contains:
+- **`backend/`** — Rails 8 API (Ruby 3.3.5, SQLite3, JWT magic-link auth, IceCube recurrence)
+- **`clients/web/`** — Vanilla JS/HTML voice reminder interface for seniors (no framework)
+- **`clients/macos-swiftui/`** — SwiftUI macOS app (Xcode project)
+- **`shared/locales/`** — i18n translation files
+
+## Commands
+
+### Setup
+```bash
+make backend-setup          # bundle install + db:create + db:migrate
+cd clients/web && npm install
+```
+
+### Running
+```bash
+./start_backend.sh          # Backend on http://localhost:5000
+cd clients/web && npm run dev  # Web client on http://localhost:8080
+make dev                    # Both via tmux (requires tmux)
+```
+
+### Testing & Linting
+```bash
+make rspec                                    # Run all backend specs
+cd backend && bundle exec rspec spec/path/to/spec.rb  # Run single spec file
+cd backend && bin/brakeman --no-pager         # Security scan (run in CI)
+cd backend && bin/rubocop -f github           # Linting (run in CI)
+```
+
+### Database
+```bash
+make backend-db             # Drop, recreate, and migrate DB
+cd backend && bin/rails db:migrate
+cd backend && bin/rails db:seed
+```
+
+### Deployment
+```bash
+./deploy.sh                 # Kamal deploy to DigitalOcean (prod)
+```
+
+## Architecture
+
+### Authentication
+Magic-link email flow — no passwords. Users request a token via `GET /magic/request?email=X`, click the emailed link, and exchange the token for a JWT via `POST /magic/verify`. The JWT is stored in localStorage (web) or Keychain (macOS). Dev shortcut: `GET /magic/dev_exchange?email=X`.
+
+### Recurrence
+Reminders and tasks use iCalendar RRULE format stored in the DB. `app/services/recurrence.rb` uses the `ice_cube` gem to expand RRULEs into concrete `occurrences` records. Occurrences drive the daily reminder display.
+
+### Data Model
+- **User** — can be a senior, caregiver, or both; linked via `CaregiverLink`
+- **Reminder** → **Occurrence** → **Acknowledgement** — core reminder loop (legacy, still used by web client)
+- **Task** — newer primary model; supports recurring templates (`rrule`), open-ended tasks (no date), and external sync from scheduling integrations
+- **TimeBlock** — senior unavailability periods; also supports RRULE recurrence
+- **SchedulingIntegration** — caregiver's external calendar (Acuity); syncs appointments as Tasks
+
+### Background Jobs (Solid Queue)
+Configured in `config/recurring.yml`. `CheckCoverageGapsJob` runs daily at 8am to detect caregiver coverage holes and send notifications.
+
+### Rails Server Configuration
+Backend runs on port 5000 (not the default 3000). CORS is enabled via `rack-cors` for cross-origin clients. `JWT_SECRET` env var is required at runtime (defaults to `please_change_me` in dev).
+
+### Clients
+- **Web client** talks to Rails REST API; `apiBaseUrl` is configurable via localStorage (defaults to `localhost:5000` or current domain origin)
+- **macOS client** configures `APIClient.base` in Xcode; uses `AVSpeechSynthesizer` for TTS
+
+### Deployment
+Kamal + Docker targeting a single DigitalOcean server (`161.35.104.56`). SQLite3 persists on a Docker volume at `/rails/storage/production.sqlite3`. The Docker entrypoint runs migrations automatically on deploy. SSL via Let's Encrypt at `remindly.anakhsoft.com`. Secrets (`KAMAL_REGISTRY_PASSWORD`, `RAILS_MASTER_KEY`) live in `.kamal/secrets`.
+
+### CI (GitHub Actions)
+Two jobs on PRs and pushes to `main`: Brakeman security scan and Rubocop lint. Tests are not run in CI (run locally with `make rspec`).
+
+## Key Environment Variables
+
+| Variable | Purpose |
+|----------|---------|
+| `JWT_SECRET` | HMAC secret for JWT signing (required) |
+| `RAILS_MASTER_KEY` | Rails credentials decryption (production) |
+| `ENABLE_NATIVE_SCHEDULING` | Feature flag for caregiver availability module |

--- a/backend/AGENTS.md
+++ b/backend/AGENTS.md
@@ -1,0 +1,197 @@
+# Ruby on Rails Codebase Guide for AI Coding Agents
+
+This is the code base of the Ruby on Rails web framework.
+
+## Architecture Overview
+
+Rails is a **monorepo containing 10+ independent components** that can work standalone or together.
+
+Each component lives in its own directory at the root level:
+
+- **Active Record** (`activerecord/`) - ORM and database abstraction
+- **Action Pack** (`actionpack/`) - Controllers and routing (contains Action Controller and Action Dispatch)
+- **Action View** (`actionview/`) - View templates and helpers (extracted from Action Pack in Rails 3)
+- **Active Model** (`activemodel/`) - Model interfaces without database dependency
+- **Active Support** (`activesupport/`) - Core extensions and utilities used across all Rails components
+- **Action Mailer** (`actionmailer/`), **Action Mailbox** (`actionmailbox/`) - Email sending/receiving
+- **Active Job** (`activejob/`) - Background job abstraction
+- **Action Cable** (`actioncable/`) - WebSocket integration
+- **Active Storage** (`activestorage/`) - File uploads and cloud storage
+- **Action Text** (`actiontext/`) - Rich text content
+- **Railties** (`railties/`) - Rails CLI, generators, and framework glue
+
+**Key architectural principle**: Rails components are loosely coupled. Changes to one of them should not break others unless there's an explicit dependency.
+
+## Testing Commands
+
+### Running Tests in a Component
+
+From within the component directory (preferred method):
+
+```bash
+cd actionview && bin/test                    # Run all tests
+cd actionview && bin/test test/template/form_helper_test.rb
+cd actionview && bin/test -n "/test_name/"   # Filter by test name pattern
+```
+
+How to run specific test method:
+
+```bash
+cd actionview && bin/test test/template/form_helper_test.rb::FormHelperTest#test_hidden_field
+```
+
+### Running Tests from Root
+
+Run all tests for a given component:
+
+```bash
+rake actionview:test
+```
+
+Run tests across all components:
+
+```bash
+rake test          # Run all non-isolated tests
+rake test:isolated # Run isolated tests
+rake smoke         # Quick smoke test
+```
+
+### Active Record Testing (Multiple Database Adapters)
+
+How to test individual database adapters in Active Record:
+
+```bash
+cd activerecord
+bundle exec rake test:sqlite3 # Default
+bundle exec rake test:postgresql
+bundle exec rake test:mysql2
+bundle exec rake test:trilogy
+```
+
+**Important**: Tests run in parallel using multiple processes. The `bin/test` script wraps Rails' custom test runner (`tools/test.rb`) which uses `Rails::TestUnit::Runner`.
+
+## Configuration Testing Patterns
+
+When testing configuration options, use `Object#with` (from Active Support) to temporarily modify class attributes:
+
+```ruby
+# Correct: Use Object#with for temporary config changes
+ActionView::Base.with(remove_hidden_field_autocomplete: true) do
+  # Test code here
+end
+
+# Avoid: Manual set/restore patterns
+old = ActionView::Base.remove_hidden_field_autocomplete
+ActionView::Base.remove_hidden_field_autocomplete = true
+# ... test code
+ActionView::Base.remove_hidden_field_autocomplete = old
+```
+
+This pattern is used throughout the test suite, especially for:
+
+- `ActionView::Base.with(config_option: value)`
+- `ActionController::Base.with(config_option: value)`
+- Other framework configuration testing
+
+**Requires**: `require "active_support/core_ext/object/with"` at the top of test files.
+
+## Code Conventions
+
+### Configuration Flags
+
+Configuration options follow a consistent pattern across components:
+
+1. **Define the attribute** in the base class (e.g., `ActionView::Base`):
+   ```ruby
+   cattr_accessor :remove_hidden_field_autocomplete, default: false
+   ```
+
+2. **Check the flag** before applying behavior:
+   ```ruby
+   @options.reverse_merge!(autocomplete: "off") unless ActionView::Base.remove_hidden_field_autocomplete
+   ```
+
+3. **Enable by default** in new Rails versions via `load_defaults`:
+   ```ruby
+   # In railties/lib/rails/application/configuration.rb
+   case target_version.to_s
+   when "8.1"
+     action_view.remove_hidden_field_autocomplete = true
+   end
+   ```
+
+### Changelog Updates
+
+When fixing bugs or adding features:
+
+- Add an entry to the top of `<component>/CHANGELOG.md`
+- Format: Brief description, then `*Your Name*` on new line
+- See existing entries for style
+
+### Test Naming
+
+- Use descriptive names: `test_hidden_field_omits_autocomplete_when_remove_hidden_field_autocomplete_is_true`
+- Group related tests together in the file
+- Test both default behavior AND explicit overrides
+
+### Code Style
+
+- Run RuboCop: `bundle exec rubocop` (there's a project-wide `.rubocop.yml`)
+- Prefer `assert_not` over `assert !` (`Rails/AssertNot` cop)
+- Prefer `assert_dom_equal` for HTML comparisons in view tests
+- Use `# frozen_string_literal: true` at top of all files
+
+## Common Development Workflows
+
+### Making a Fix Across Multiple Components
+
+Example: Issue #55984 required changes to:
+
+1. Helper class: `actionview/lib/action_view/helpers/tags/hidden_field.rb`
+2. Tests: `actionview/test/template/form_helper_test.rb`
+3. Reference: Similar fixes were in `tags/check_box.rb`, `tags/file_field.rb`, `form_tag_helper.rb`, `url_helper.rb`
+
+**Pattern**: When fixing a configuration flag, grep for similar patterns in other helpers:
+
+```bash
+grep -r "unless ActionView::Base.remove_hidden_field_autocomplete" actionview/lib/
+```
+
+### Finding Related Code
+
+- **Similar functionality**: Look in the same `lib/*/helpers/` or `lib/*/tags/` directory
+- **Tests for a helper**: Check `test/template/<helper_name>_test.rb`
+- **Configuration setup**: Check `railties/lib/rails/application/configuration.rb`
+- **Default values**: Look for `load_defaults` version blocks
+
+### Working with Forms and Helpers
+
+Action View helpers follow this structure:
+
+- **Tag helpers** (`lib/action_view/helpers/tags/`) - Individual form elements
+- **Form helpers** (`lib/action_view/helpers/form_helper.rb`) - Form builders
+- **Form tag helpers** (`lib/action_view/helpers/form_tag_helper.rb`) - Standalone tags
+
+When modifying form behavior, check ALL three locations for consistency.
+
+## Issue References and Pull Requests
+
+- Always reference issue numbers in commits: `Fix #12345: Description`
+- Check for previous related PRs/issues when fixing bugs
+- Look at PR #55336 pattern when working on similar autocomplete-related fixes
+- Bug report templates live in `guides/bug_report_templates/`
+
+## File Organization Principles
+
+- `lib/` - Production code
+- `test/` - Test files (NOT `spec/` - Rails uses Minitest, not RSpec)
+- `bin/` - Executable scripts (e.g., `bin/test`)
+- Each framework is self-contained with its own Gemfile and dependencies
+- Shared tools live in `tools/` (e.g., `tools/test.rb`, `tools/release.rb`)
+
+## Documentation
+
+- API docs use YARD/RDoc format
+- Guides source in `guides/source/` (Markdown)
+- Generate docs: `rake rdoc` (from framework directory)
+- Configuration options documented in `guides/source/configuring.md`

--- a/backend/config/deploy.yml
+++ b/backend/config/deploy.yml
@@ -12,7 +12,7 @@ servers:
 # Enable SSL auto certification via Let's Encrypt
 proxy:
   ssl: true
-  host: remindly.anakhsoft.com
+  host: remindly.anakhsoft.com,remindly.care,www.remindly.care
 
 # Credentials for your image host (DigitalOcean Container Registry)
 registry:

--- a/backend/config/environments/production.rb
+++ b/backend/config/environments/production.rb
@@ -87,7 +87,8 @@ Rails.application.configure do
   # Skip DNS rebinding protection for the default health check endpoint.
   config.host_authorization = { exclude: ->(request) { request.path == "/up" } }
   
-  # Allow requests from remindly.care domain
+  # Allow requests from all configured domains
+  config.hosts << "remindly.anakhsoft.com"
   config.hosts << "remindly.care"
   config.hosts << "www.remindly.care"
 end

--- a/backend/config/environments/production.rb
+++ b/backend/config/environments/production.rb
@@ -85,7 +85,7 @@ Rails.application.configure do
   # ]
   #
   # Skip DNS rebinding protection for the default health check endpoint.
-  # config.host_authorization = { exclude: ->(request) { request.path == "/up" } }
+  config.host_authorization = { exclude: ->(request) { request.path == "/up" } }
   
   # Allow requests from remindly.care domain
   config.hosts << "remindly.care"

--- a/backend/config/environments/production.rb
+++ b/backend/config/environments/production.rb
@@ -86,4 +86,8 @@ Rails.application.configure do
   #
   # Skip DNS rebinding protection for the default health check endpoint.
   # config.host_authorization = { exclude: ->(request) { request.path == "/up" } }
+  
+  # Allow requests from remindly.care domain
+  config.hosts << "remindly.care"
+  config.hosts << "www.remindly.care"
 end


### PR DESCRIPTION
## Changes
- Add remindly.care and www.remindly.care domains with SSL certificates
- Add remindly.anakhsoft.com to allowed hosts
- Exclude /up health check from host authorization
- Add AI assistant documentation (CLAUDE.md, AGENTS.md)

## Testing
All three domains verified working with HTTPS:
- https://remindly.anakhsoft.com ✅
- https://remindly.care ✅
- https://www.remindly.care ✅

Already deployed and tested in production.