### PR TITLE
Skip daily audit report email when there is no login activity

### DIFF
--- a/backend/lib/tasks/audit_reports.rake
+++ b/backend/lib/tasks/audit_reports.rake
@@ -17,19 +17,29 @@ namespace :audit do
     end
 
     date = Date.yesterday
-    puts "📧 Sending daily audit report for #{date.strftime('%B %d, %Y')} to #{recipient_email}..."
 
-    begin
-      AuditReportMailer.daily_report(
-        date: date,
-        recipient_email: recipient_email
-      ).deliver_now
+    event_count = Ahoy::Event
+      .where(name: ["Login Success", "Login Failed", "Logout"])
+      .where(time: date.beginning_of_day..date.end_of_day)
+      .count
 
-      puts "✅ Daily audit report sent successfully!"
-    rescue => e
-      puts "❌ Error sending audit report: #{e.message}"
-      puts e.backtrace.join("\n")
-      raise e
+    if event_count.zero?
+      puts "ℹ️  No login/logout activity for #{date.strftime('%B %d, %Y')} — skipping audit report email."
+    else
+      puts "📧 Sending daily audit report for #{date.strftime('%B %d, %Y')} to #{recipient_email}..."
+
+      begin
+        AuditReportMailer.daily_report(
+          date: date,
+          recipient_email: recipient_email
+        ).deliver_now
+
+        puts "✅ Daily audit report sent successfully!"
+      rescue => e
+        puts "❌ Error sending audit report: #{e.message}"
+        puts e.backtrace.join("\n")
+        raise e
+      end
     end
   end
 


### PR DESCRIPTION
## Summary
The automated `audit:daily_report` rake task previously sent an email even when all event counts (total events, successful logins, failed logins, logouts) were zero. This guards the send with an event-count check so days with no login/logout activity are skipped.

## Change
`backend/lib/tasks/audit_reports.rake` — before sending, count `Login Success` / `Login Failed` / `Logout` Ahoy events for the target day; if zero, print a skip notice and `next` without delivering.

Only the automated daily task is affected. The manual `audit:report_for_date[...]` task still always sends, so an explicit request for a specific date works even if empty.

## Testing
Ran `AUDIT_REPORT_EMAIL=test@example.com bundle exec rake audit:daily_report` against a dev DB with no activity:

```
ℹ️  No login/logout activity for July 08, 2026 — skipping audit report email.
```

No email delivered on the empty-day path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)