### PR TITLE
Fix occurrence generation dropping today's reminders for ahead-of-local timezones

### DIFF
--- a/backend/app/services/recurrence.rb
+++ b/backend/app/services/recurrence.rb
@@ -28,10 +28,10 @@ class Recurrence
     all_occurrences = schedule.occurrences_between(start_time, stop)
     Rails.logger.info "📋 IceCube found #{all_occurrences.count} occurrences"
     
+    today_start = now.beginning_of_day
     all_occurrences.each_with_index do |t, idx|
-      Rails.logger.info "  [#{idx}] #{t} (#{t >= now - 1.hour ? 'WILL CREATE' : 'SKIP - too old'})"
-      # Only create if it's in the future or within the last hour (for today's reminders)
-      if t >= now - 1.hour
+      Rails.logger.info "  [#{idx}] #{t} (#{t >= today_start ? 'WILL CREATE' : 'SKIP - before today'})"
+      if t >= today_start
         begin
           occurrence = reminder.occurrences.find_or_create_by!(scheduled_at: t)
           Rails.logger.info "    ✅ Occurrence id=#{occurrence.id} for #{t}"

--- a/backend/app/services/recurrence.rb
+++ b/backend/app/services/recurrence.rb
@@ -29,18 +29,35 @@ class Recurrence
     Rails.logger.info "📋 IceCube found #{all_occurrences.count} occurrences"
     
     today_start = now.beginning_of_day
+
+    # Decide which occurrences to materialize.
+    #
+    # Always create current/upcoming occurrences (>= now). For occurrences whose
+    # time has already passed *today*, create only the most recent one — the
+    # "current" period. This keeps a same-day reminder visible even after its
+    # clock time has passed (e.g. a caregiver in EST sets a reminder that is
+    # already in the past for a senior in IST) without backfilling every earlier
+    # slot of the day. Without this, an hourly / BYHOUR reminder opened for the
+    # first time in the afternoon would spawn a pending occurrence for every
+    # earlier hour, nagging the senior with stale reminders.
+    upcoming, past = all_occurrences.partition { |t| t >= now }
+    most_recent_past = past.select { |t| t >= today_start }.max
+    to_create = upcoming
+    to_create << most_recent_past if most_recent_past
+
     all_occurrences.each_with_index do |t, idx|
-      Rails.logger.info "  [#{idx}] #{t} (#{t >= today_start ? 'WILL CREATE' : 'SKIP - before today'})"
-      if t >= today_start
-        begin
-          occurrence = reminder.occurrences.find_or_create_by!(scheduled_at: t)
-          Rails.logger.info "    ✅ Occurrence id=#{occurrence.id} for #{t}"
-        rescue ActiveRecord::RecordNotUnique => e
-          Rails.logger.warn "    ⚠️ Duplicate occurrence prevented for #{t}: #{e.message}"
-          # Occurrence already exists, fetch it
-          occurrence = reminder.occurrences.find_by!(scheduled_at: t)
-          Rails.logger.info "    ✅ Found existing occurrence id=#{occurrence.id}"
-        end
+      Rails.logger.info "  [#{idx}] #{t} (#{to_create.include?(t) ? 'WILL CREATE' : 'SKIP'})"
+    end
+
+    to_create.sort.each do |t|
+      begin
+        occurrence = reminder.occurrences.find_or_create_by!(scheduled_at: t)
+        Rails.logger.info "    ✅ Occurrence id=#{occurrence.id} for #{t}"
+      rescue ActiveRecord::RecordNotUnique => e
+        Rails.logger.warn "    ⚠️ Duplicate occurrence prevented for #{t}: #{e.message}"
+        # Occurrence already exists, fetch it
+        occurrence = reminder.occurrences.find_by!(scheduled_at: t)
+        Rails.logger.info "    ✅ Found existing occurrence id=#{occurrence.id}"
       end
     end
   end

--- a/backend/spec/services/recurrence_spec.rb
+++ b/backend/spec/services/recurrence_spec.rb
@@ -1,0 +1,93 @@
+require 'rails_helper'
+
+RSpec.describe Recurrence do
+  include ActiveSupport::Testing::TimeHelpers
+
+  let(:tz) { "America/New_York" }
+  let(:senior) { create(:user, :senior, tz: tz) }
+
+  # 5:30 PM in the reminder's timezone — well past a morning reminder.
+  let(:afternoon) { ActiveSupport::TimeZone[tz].local(2026, 7, 9, 17, 30, 0) }
+
+  around do |example|
+    travel_to(afternoon) { example.run }
+  end
+
+  describe ".expand" do
+    context "with a once-daily reminder whose time has already passed today" do
+      let(:reminder) do
+        senior.reminders.create!(
+          title: "Morning pills",
+          rrule: "FREQ=DAILY;BYHOUR=9;BYMINUTE=0",
+          tz: tz
+        )
+      end
+
+      it "still creates today's occurrence so it is not silently dropped" do
+        Recurrence.expand(reminder)
+
+        today_nine = ActiveSupport::TimeZone[tz].local(2026, 7, 9, 9, 0, 0)
+        expect(reminder.occurrences.where(scheduled_at: today_nine)).to exist
+      end
+
+      it "also creates tomorrow's upcoming occurrence" do
+        Recurrence.expand(reminder)
+
+        tomorrow_nine = ActiveSupport::TimeZone[tz].local(2026, 7, 10, 9, 0, 0)
+        expect(reminder.occurrences.where(scheduled_at: tomorrow_nine)).to exist
+      end
+    end
+
+    context "with an hourly reminder opened for the first time in the afternoon" do
+      let(:reminder) do
+        senior.reminders.create!(
+          title: "Drink water",
+          rrule: "FREQ=HOURLY",
+          tz: tz,
+          start_time: ActiveSupport::TimeZone[tz].local(2026, 7, 9, 0, 0, 0)
+        )
+      end
+
+      it "does not backfill every earlier hour of the day" do
+        Recurrence.expand(reminder)
+
+        today_start = ActiveSupport::TimeZone[tz].local(2026, 7, 9, 0, 0, 0)
+        past_today = reminder.occurrences.where(scheduled_at: today_start...afternoon)
+
+        # Only the most recent past slot (5 PM) should be materialized, not the
+        # 17 earlier hours of the day.
+        five_pm = ActiveSupport::TimeZone[tz].local(2026, 7, 9, 17, 0, 0)
+        expect(past_today.count).to eq(1)
+        expect(past_today.first.scheduled_at).to eq(five_pm)
+      end
+
+      it "still creates upcoming occurrences" do
+        Recurrence.expand(reminder)
+
+        six_pm = ActiveSupport::TimeZone[tz].local(2026, 7, 9, 18, 0, 0)
+        expect(reminder.occurrences.where(scheduled_at: six_pm)).to exist
+      end
+    end
+
+    context "when the current occurrence was already acknowledged" do
+      let(:reminder) do
+        senior.reminders.create!(
+          title: "Morning pills",
+          rrule: "FREQ=DAILY;BYHOUR=9;BYMINUTE=0",
+          tz: tz
+        )
+      end
+      let(:today_nine) { ActiveSupport::TimeZone[tz].local(2026, 7, 9, 9, 0, 0) }
+
+      it "does not reset it back to pending" do
+        reminder.occurrences.create!(scheduled_at: today_nine, status: :acknowledged)
+
+        Recurrence.expand(reminder)
+
+        occurrence = reminder.occurrences.find_by!(scheduled_at: today_nine)
+        expect(occurrence).to be_status_acknowledged
+        expect(reminder.occurrences.where(scheduled_at: today_nine).count).to eq(1)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary
The previous `now - 1.hour` guard in `Recurrence.expand` caused occurrences to be silently skipped when a caregiver in one timezone (e.g. EST) created reminders for a senior in a timezone significantly ahead (e.g. IST, +5:30). The reminder time would already be > 1 hour in the past in the senior's timezone, so only tomorrow's occurrence was created and the senior saw nothing today.

This changes the lower bound so a same-day reminder is always created even after its clock time has passed.

## Follow-up: avoiding the stale-occurrence flood
A first pass simply used `now.beginning_of_day` as the cutoff, but review flagged that this backfills **every** earlier slot of the day — an hourly/BYHOUR reminder opened in the afternoon would spawn a pending occurrence for each past hour, nagging the senior with stale reminders.

Resolved in `2933330`: `expand` now always creates current/upcoming occurrences and, for times already passed today, creates **only the most recent one** (the current period). A once-daily reminder still surfaces after its time passes; hourly reminders no longer flood. Already-acknowledged occurrences are left untouched via the idempotent `find_or_create_by!`.

## Testing
Adds `spec/services/recurrence_spec.rb` (5 examples) covering:
- once-daily reminder past its time still creates today's occurrence (the timezone fix)
- hourly reminder creates only the most recent past slot, not every earlier hour
- an already-acknowledged occurrence is not reset to pending

Full suite: 102 examples, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)