### PR TITLE
fix(api): let the voice client acknowledge reminders

### DIFF
--- a/backend/app/controllers/acknowledgements_controller.rb
+++ b/backend/app/controllers/acknowledgements_controller.rb
@@ -1,4 +1,4 @@
-class AcknowledgementsController < WebController
+class AcknowledgementsController < ApplicationController
   before_action :authenticate!
 
   def create

--- a/backend/spec/requests/acknowledgements_spec.rb
+++ b/backend/spec/requests/acknowledgements_spec.rb
@@ -1,0 +1,65 @@
+require 'rails_helper'
+
+RSpec.describe "Acknowledgements", type: :request do
+  # The voice web client authenticates with a Bearer token and sends no CSRF
+  # token. When this controller inherited from WebController (ActionController::Base
+  # with protect_from_forgery), every POST failed with 422 before reaching the
+  # database — seniors could read reminders but never mark one taken.
+  let(:user) { User.create!(email: "senior@example.com", tz: "America/New_York") }
+  let(:jwt) { JWT.encode({ uid: user.id, exp: 1.hour.from_now.to_i }, ENV.fetch("JWT_SECRET", "dev_secret_change_me"), "HS256") }
+
+  let(:occurrence) do
+    reminder = Reminder.create!(user: user, title: "Pill", rrule: "FREQ=DAILY", tz: user.tz)
+    Occurrence.create!(reminder: reminder, scheduled_at: Time.current, status: :pending)
+  end
+
+  def auth_headers = { "Authorization" => "Bearer #{jwt}" }
+
+  describe "POST /acknowledgements" do
+    it "accepts a Bearer-authenticated request without a CSRF token" do
+      post "/acknowledgements",
+        params: { occurrence_id: occurrence.id, kind: "taken" },
+        headers: auth_headers
+      expect(response).to have_http_status(:created)
+    end
+
+    it "records the acknowledgement and marks the occurrence acknowledged" do
+      post "/acknowledgements",
+        params: { occurrence_id: occurrence.id, kind: "taken" },
+        headers: auth_headers
+
+      expect(occurrence.reload.status).to eq("acknowledged")
+      expect(occurrence.acknowledgements.last.kind).to eq("taken")
+    end
+
+    it "rejects an unauthenticated request" do
+      post "/acknowledgements", params: { occurrence_id: occurrence.id, kind: "taken" }
+      expect(response).to have_http_status(:unauthorized)
+    end
+
+    it "does not let one user acknowledge another user's occurrence" do
+      other = User.create!(email: "intruder@example.com", tz: "America/New_York")
+      other_jwt = JWT.encode({ uid: other.id, exp: 1.hour.from_now.to_i }, ENV.fetch("JWT_SECRET", "dev_secret_change_me"), "HS256")
+
+      post "/acknowledgements",
+        params: { occurrence_id: occurrence.id, kind: "taken" },
+        headers: { "Authorization" => "Bearer #{other_jwt}" }
+
+      expect(response).to have_http_status(:not_found)
+      expect(occurrence.reload.status).to eq("pending")
+    end
+  end
+
+  describe "POST /acknowledgements/snooze" do
+    it "accepts a Bearer-authenticated snooze and schedules a new occurrence" do
+      expect {
+        post "/acknowledgements/snooze",
+          params: { occurrence_id: occurrence.id, minutes: 15 },
+          headers: auth_headers
+      }.to change { occurrence.reminder.occurrences.count }.by(1)
+
+      expect(response).to have_http_status(:created)
+      expect(occurrence.reload.status).to eq("acknowledged")
+    end
+  end
+end


### PR DESCRIPTION
## The bug

On the voice web client, **seniors can never mark a reminder taken, snoozed, or skipped.** Reads work fine, so the client looks healthy — the reminder simply doesn't go away when you tap ✓ Taken.

This is live in production today.

## Root cause

`AcknowledgementsController` inherited from `WebController`, which is an `ActionController::Base` subclass with `protect_from_forgery with: :exception`, authenticating from the session or an encrypted cookie:

```ruby
token = session[:jwt_token] || cookies.encrypted[:jwt_token]
```

The voice client sends `Authorization: Bearer <jwt>` and no CSRF token (`public/client/app.js:889`). The forgery check rejected every POST with `InvalidAuthenticityToken` → **422 in 1ms with 0 queries** — it never reached the enum or the database.

`RemindersController` inherits `ApplicationController` (`ActionController::API`, Bearer header), which is exactly why every GET succeeded and only writes failed.

## The fix

One line — inherit the API base class instead:

```diff
-class AcknowledgementsController < WebController
+class AcknowledgementsController < ApplicationController
```

## Why this is safe

Nothing else posts to this controller. The dashboard views only *read* acknowledgements (`dashboard/senior.html.erb:90,134`) — there's no form or `button_to`, so no server-rendered form loses CSRF protection. The voice client is the sole writer.

## Verification

- Direct POST with Bearer auth: **422 → 201**
- Confirmed end-to-end in a browser against the running app: card moved to Completed, counters went Pending 1→0, Completed 0→1
- Full suite: **118 examples, 0 failures**
- New request specs cover the Bearer path, unauthenticated rejection, cross-user isolation, and snooze. **All five fail against the previous parent class** — verified by reverting the fix, not just by watching them pass.

## Note

This bug had no test coverage, which is how it survived. The specs added here would catch a regression if someone changes the parent class again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)