### PR TITLE
fix(api): accept both session and Bearer auth for acknowledgements

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,7 +74,15 @@ Backend runs on port 5000 (not the default 3000). CORS is enabled via `rack-cors
 Kamal + Docker targeting a single DigitalOcean server (`161.35.104.56`). SQLite3 persists on a Docker volume at `/rails/storage/production.sqlite3`. The Docker entrypoint runs migrations automatically on deploy. SSL via Let's Encrypt at `remindly.anakhsoft.com`. Secrets (`KAMAL_REGISTRY_PASSWORD`, `RAILS_MASTER_KEY`) live in `.kamal/secrets`.
 
 ### CI (GitHub Actions)
-Two jobs on PRs and pushes to `main`: Brakeman security scan and Rubocop lint. Tests are not run in CI (run locally with `make rspec`).
+Two jobs on PRs and pushes to `main`, defined in `.github/workflows/ci.yml`:
+- **`test`** — runs the full RSpec suite, including the guard specs that enforce repo invariants (`web_client_sync_spec.rb` for client drift, `public_assets_spec.rb` for files served from `public/`)
+- **`scan_ruby`** — Brakeman security scan
+
+The workflow **must stay at the repository root**. It previously lived at `backend/.github/workflows/ci.yml`, where GitHub Actions never reads, so it had never run — no PR reported a check until 2026-07-18.
+
+Rubocop is deliberately not wired up yet: it reports ~683 offenses (~620 auto-correctable), so enabling it would fail every PR. `.github/workflows/ci.yml` marks where the job goes once that is cleaned up.
+
+`bin/brakeman` prepends `--ensure-latest`, so the scan fails when the gem falls behind the latest release — update the gem rather than removing the flag.
 
 ## Key Environment Variables
 

--- a/backend/app/controllers/acknowledgements_controller.rb
+++ b/backend/app/controllers/acknowledgements_controller.rb
@@ -1,4 +1,17 @@
-class AcknowledgementsController < ApplicationController
+# Two different clients acknowledge reminders, and they authenticate differently:
+#
+#   /voice_reminders   Rails page, session cookie + CSRF token (what seniors use)
+#   /client/           static JS app, Authorization: Bearer <jwt>, no CSRF token
+#
+# Inheriting from WebController alone rejected the Bearer client at the forgery
+# check (422); inheriting from ApplicationController alone rejected the session
+# client, because its current_user only reads the Authorization header (401).
+# Either choice breaks one of them, so this accepts both.
+class AcknowledgementsController < WebController
+  # Only skip forgery protection for requests that carry a Bearer token, which a
+  # browser will not send cross-site. Session requests keep CSRF protection.
+  skip_forgery_protection if: -> { bearer_user.present? }
+
   before_action :authenticate!
 
   def create
@@ -26,10 +39,36 @@ class AcknowledgementsController < ApplicationController
     # Mark original as acknowledged
     occ.update!(status: :acknowledged)
     
-    render json: { 
+    render json: {
       snoozed_occurrence_id: new_occ.id,
       scheduled_at: new_occ.scheduled_at,
       minutes: minutes
     }, status: :created
+  end
+
+  private
+
+  # Bearer first (the JS client), falling back to WebController's session lookup
+  # (the /voice_reminders page).
+  def current_user
+    @current_user ||= bearer_user || super
+  end
+
+  def bearer_user
+    return @bearer_user if defined?(@bearer_user)
+
+    @bearer_user = begin
+      token = request.authorization&.split(" ")&.last
+      payload = token && JWT.decode(token, hmac_secret, true, { algorithm: "HS256" }).first
+      User.find_by(id: payload&.fetch("uid", nil))
+    rescue JWT::DecodeError
+      nil
+    end
+  end
+
+  # WebController redirects to the login page when unauthenticated, which is
+  # meaningless to both of these clients — they want a status code.
+  def authenticate!
+    head :unauthorized unless current_user
   end
 end

--- a/backend/spec/requests/acknowledgements_spec.rb
+++ b/backend/spec/requests/acknowledgements_spec.rb
@@ -50,6 +50,35 @@ RSpec.describe "Acknowledgements", type: :request do
     end
   end
 
+  # /voice_reminders is the page seniors actually use, and it authenticates with
+  # the Rails session rather than a Bearer token. The original fix here moved the
+  # controller to ApplicationController, whose current_user only reads the
+  # Authorization header — which fixed the JS client and silently broke this one.
+  # Nothing covered the session path, so the swap looked green.
+  describe "session-authenticated requests (the /voice_reminders page)" do
+    def sign_in(user)
+      jwt = JWT.encode({ uid: user.id, exp: 1.hour.from_now.to_i }, ENV.fetch("JWT_SECRET", "dev_secret_change_me"), "HS256")
+      # Mirrors how the dashboard establishes a session after magic-link verify.
+      post "/magic/verify", params: { token: user.signed_id(purpose: :magic_login, expires_in: 30.minutes) }
+      jwt
+    end
+
+    it "accepts a session-authenticated acknowledgement" do
+      sign_in(user)
+      post "/acknowledgements", params: { occurrence_id: occurrence.id, kind: "taken" }
+
+      expect(response).to have_http_status(:created)
+      expect(occurrence.reload.status).to eq("acknowledged")
+    end
+
+    it "accepts a session-authenticated snooze" do
+      sign_in(user)
+      post "/acknowledgements/snooze", params: { occurrence_id: occurrence.id, minutes: 15 }
+
+      expect(response).to have_http_status(:created)
+    end
+  end
+
   describe "POST /acknowledgements/snooze" do
     it "accepts a Bearer-authenticated snooze and schedules a new occurrence" do
       expect {


### PR DESCRIPTION
> **Production regression introduced by #27.** Done and Snooze are currently broken on `/voice_reminders` — the page the dashboard links seniors to.

## What broke

Two clients acknowledge reminders, and they authenticate differently:

| Client | Auth |
|---|---|
| `/voice_reminders` (Rails page, **what seniors use**) | session cookie + CSRF token |
| `/client/` (static JS app) | `Authorization: Bearer <jwt>`, no CSRF token |

Under `WebController`, the Bearer client was rejected at the forgery check → **422**.

#27 moved the controller to `ApplicationController`, whose `current_user` reads only the `Authorization` header:

```ruby
token = request.authorization&.split(" ")&.last
```

A session request therefore resolves `current_user` to `nil` → `authenticate!` → **401**. That fixed the JS client and silently broke the session one. Since `/voice_reminders` is what the dashboard links to, the net effect was to break acknowledgement for the people who actually use it.

## Why nothing caught it

Three independent failures, all of the same shape — a check that passes without verifying the thing that matters:

1. **The specs added in #27 only covered the Bearer path.** Swapping which client worked left them green.
2. **My production verification posted without credentials** and read the resulting 401 as proof the fix worked. But 401 is exactly what a *legitimate* session request now returns — I confirmed the failure and called it success.
3. **Nobody checked which client was in use** before changing shared code. The work followed a handoff pointing at `clients/web/`, and everything downstream inherited that assumption — including iPhone testing that validated a page seniors do not open.

## The fix

The controller accepts either credential rather than swapping which one works:

- `current_user` tries the Bearer token first, falling back to `WebController`'s session lookup
- Forgery protection is skipped **only** for requests carrying a Bearer token, which a browser will not send cross-site — session requests keep CSRF protection
- `authenticate!` returns 401 instead of redirecting to a login page, which neither client can consume

## Verification

Against **the exact controller currently deployed**:

```
7 examples, 2 failures
  session-authenticated acknowledgement  FAILED
  session-authenticated snooze           FAILED
```

The five Bearer examples pass — reproducing the regression precisely.

With this fix: **7 pass**, full suite **120 examples, 0 failures**.

## Follow-up

`/voice_reminders` still runs `public/voice_reminders.js`, a third copy of the voice logic (last touched Nov 30 2025) that never received the voice-unlock or replay work from #29. Porting that is next, separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)