### PR TITLE
fix(api): snoozing must not move a reminder earlier

### DIFF
--- a/backend/app/controllers/acknowledgements_controller.rb
+++ b/backend/app/controllers/acknowledgements_controller.rb
@@ -39,22 +39,30 @@ class AcknowledgementsController < WebController
     occ = Occurrence.joins(:reminder).where(reminders: { user_id: current_user.id }).find(params.require(:occurrence_id))
     minutes = snooze_minutes
 
-    # Create acknowledgement for snooze tracking
-    Acknowledgement.create!(occurrence: occ, kind: 'snooze', at: Time.current)
-
     # Measure from whichever is later: the time it was due, or now. Before the due
     # time that delays the original; after it, it delays from the moment the
     # senior asked.
     base = [ occ.scheduled_at, Time.current ].max
+    target = base + minutes.minutes
 
-    new_occ = Occurrence.create!(
-      reminder: occ.reminder,
-      scheduled_at: base + minutes.minutes,
-      status: :pending
-    )
+    # Making the target deterministic also makes a retry collide: occurrences are
+    # unique on (reminder_id, scheduled_at), so a second request for the same
+    # snooze — a lost response, a double tap — would raise RecordNotUnique and
+    # return 500 for a snooze that had already succeeded. The same collision
+    # occurs when the target lands on an already-materialised recurrence.
+    #
+    # find_or_create_by makes the retry idempotent, and the transaction keeps a
+    # failure from leaving the acknowledgement behind without its occurrence.
+    new_occ = nil
+    ActiveRecord::Base.transaction do
+      Acknowledgement.create!(occurrence: occ, kind: 'snooze', at: Time.current)
 
-    # Mark original as acknowledged
-    occ.update!(status: :acknowledged)
+      new_occ = Occurrence.find_or_create_by!(reminder: occ.reminder, scheduled_at: target) do |o|
+        o.status = :pending
+      end
+
+      occ.update!(status: :acknowledged)
+    end
     
     render json: {
       snoozed_occurrence_id: new_occ.id,

--- a/backend/app/controllers/acknowledgements_controller.rb
+++ b/backend/app/controllers/acknowledgements_controller.rb
@@ -39,26 +39,36 @@ class AcknowledgementsController < WebController
     occ = Occurrence.joins(:reminder).where(reminders: { user_id: current_user.id }).find(params.require(:occurrence_id))
     minutes = snooze_minutes
 
-    # Measure from whichever is later: the time it was due, or now. Before the due
-    # time that delays the original; after it, it delays from the moment the
-    # senior asked.
-    base = [ occ.scheduled_at, Time.current ].max
-    target = base + minutes.minutes
-
-    # Making the target deterministic also makes a retry collide: occurrences are
-    # unique on (reminder_id, scheduled_at), so a second request for the same
-    # snooze — a lost response, a double tap — would raise RecordNotUnique and
-    # return 500 for a snooze that had already succeeded. The same collision
-    # occurs when the target lands on an already-materialised recurrence.
+    # A retry — a lost response, a double tap — must land on the same snoozed
+    # occurrence rather than creating another one or failing.
     #
-    # find_or_create_by makes the retry idempotent, and the transaction keeps a
-    # failure from leaving the acknowledgement behind without its occurrence.
+    # The snooze time is derived from the first snooze acknowledgement for this
+    # occurrence, not from Time.current. Measuring from "now" is only stable
+    # before the scheduled time; once it has passed, every retry would compute a
+    # later target and create another occurrence. Reusing the acknowledgement
+    # makes both sides of the due time deterministic, and keeps a retry from
+    # stacking up duplicate snooze acknowledgements.
     new_occ = nil
-    ActiveRecord::Base.transaction do
-      Acknowledgement.create!(occurrence: occ, kind: 'snooze', at: Time.current)
+    target = nil
 
-      new_occ = Occurrence.find_or_create_by!(reminder: occ.reminder, scheduled_at: target) do |o|
-        o.status = :pending
+    ActiveRecord::Base.transaction do
+      ack = occ.acknowledgements.find_by(kind: :snooze) ||
+            Acknowledgement.create!(occurrence: occ, kind: "snooze", at: Time.current)
+
+      # Whichever is later: the time it was due, or the moment it was snoozed.
+      base = [ occ.scheduled_at, ack.at ].max
+      target = base + minutes.minutes
+
+      # Occurrences are unique on (reminder_id, scheduled_at), so the target may
+      # already exist — from a retry, or from an already-materialised recurrence.
+      # find_or_create_by is a SELECT then an INSERT, so a concurrent double tap
+      # can still lose the race; the rescue takes the row the other request won.
+      new_occ = begin
+        Occurrence.find_or_create_by!(reminder: occ.reminder, scheduled_at: target) do |o|
+          o.status = :pending
+        end
+      rescue ActiveRecord::RecordNotUnique
+        Occurrence.find_by!(reminder: occ.reminder, scheduled_at: target)
       end
 
       occ.update!(status: :acknowledged)

--- a/backend/app/controllers/acknowledgements_controller.rb
+++ b/backend/app/controllers/acknowledgements_controller.rb
@@ -65,12 +65,16 @@ class AcknowledgementsController < WebController
 
   private
 
-  # A non-numeric or negative value would otherwise become 0 or a negative offset
-  # via to_i, which is the same "reminder moves earlier" failure by another route.
+  # Strict parsing, because to_i turns "not-a-number" into 0 — which then clamps to
+  # one minute rather than falling back to the default, quietly making the snooze
+  # far shorter than the senior expected. Anything unparseable or missing means we
+  # do not know what was asked for, so use the default; a value we can read but
+  # that is too small is a different case and gets clamped.
   def snooze_minutes
-    raw = params[:minutes]
-    minutes = raw.presence ? raw.to_i : SNOOZE_DEFAULT_MINUTES
-    [ minutes, SNOOZE_MIN_MINUTES ].max
+    parsed = Integer(params[:minutes].to_s, exception: false)
+    return SNOOZE_DEFAULT_MINUTES if parsed.nil?
+
+    [ parsed, SNOOZE_MIN_MINUTES ].max
   end
 
   # A Bearer header is a claim about who is acting, so it decides the outcome on

--- a/backend/app/controllers/acknowledgements_controller.rb
+++ b/backend/app/controllers/acknowledgements_controller.rb
@@ -28,20 +28,31 @@ class AcknowledgementsController < WebController
     head :created
   end
 
+  # Snoozing must never move a reminder earlier. The senior UI shows Snooze before
+  # the scheduled time, so "10 minutes from now" would reschedule a 10:25 reminder
+  # tapped at 10:00 to 10:10 — 15 minutes *earlier* than it was already going to
+  # arrive, which is the opposite of what the word means.
+  SNOOZE_DEFAULT_MINUTES = 10
+  SNOOZE_MIN_MINUTES = 1
+
   def snooze
     occ = Occurrence.joins(:reminder).where(reminders: { user_id: current_user.id }).find(params.require(:occurrence_id))
-    minutes = params.fetch(:minutes, 10).to_i # Default 10 minutes
-    
+    minutes = snooze_minutes
+
     # Create acknowledgement for snooze tracking
     Acknowledgement.create!(occurrence: occ, kind: 'snooze', at: Time.current)
-    
-    # Create new occurrence for snoozed time
+
+    # Measure from whichever is later: the time it was due, or now. Before the due
+    # time that delays the original; after it, it delays from the moment the
+    # senior asked.
+    base = [ occ.scheduled_at, Time.current ].max
+
     new_occ = Occurrence.create!(
       reminder: occ.reminder,
-      scheduled_at: minutes.minutes.from_now,
+      scheduled_at: base + minutes.minutes,
       status: :pending
     )
-    
+
     # Mark original as acknowledged
     occ.update!(status: :acknowledged)
     
@@ -53,6 +64,14 @@ class AcknowledgementsController < WebController
   end
 
   private
+
+  # A non-numeric or negative value would otherwise become 0 or a negative offset
+  # via to_i, which is the same "reminder moves earlier" failure by another route.
+  def snooze_minutes
+    raw = params[:minutes]
+    minutes = raw.presence ? raw.to_i : SNOOZE_DEFAULT_MINUTES
+    [ minutes, SNOOZE_MIN_MINUTES ].max
+  end
 
   # A Bearer header is a claim about who is acting, so it decides the outcome on
   # its own: if it is present but invalid, the request is unauthenticated, not

--- a/backend/spec/requests/acknowledgements_spec.rb
+++ b/backend/spec/requests/acknowledgements_spec.rb
@@ -146,11 +146,16 @@ RSpec.describe "Acknowledgements", type: :request do
   # The senior UI shows Snooze before the scheduled time, so this is reachable by
   # tapping the button early — not an edge case.
   describe "snoozing never moves a reminder earlier" do
+    # Assert the response before parsing it. Without this, an unrelated failure —
+    # auth, a routing change — surfaces as a JSON parse error on an error page,
+    # which hides what actually broke.
     def snooze!(occ, minutes: nil)
       params = { occurrence_id: occ.id }
       params[:minutes] = minutes unless minutes.nil?
       post "/acknowledgements/snooze", params: params, headers: auth_headers
-      Occurrence.find(JSON.parse(response.body)["snoozed_occurrence_id"])
+
+      expect(response).to have_http_status(:created), "snooze failed: #{response.status} #{response.body}"
+      Occurrence.find(JSON.parse(response.body).fetch("snoozed_occurrence_id"))
     end
 
     it "delays from the scheduled time when snoozed before it is due" do
@@ -170,7 +175,7 @@ RSpec.describe "Acknowledgements", type: :request do
       expect(new_occ.scheduled_at).to be_within(5.seconds).of(10.minutes.from_now)
     end
 
-    it "does not accept a negative delay" do
+    it "clamps a negative delay to the minimum rather than scheduling earlier" do
       new_occ = snooze!(occurrence, minutes: -30)
       expect(new_occ.scheduled_at).to be > occurrence.scheduled_at
     end

--- a/backend/spec/requests/acknowledgements_spec.rb
+++ b/backend/spec/requests/acknowledgements_spec.rb
@@ -208,6 +208,30 @@ RSpec.describe "Acknowledgements", type: :request do
       }.not_to change { Occurrence.where(reminder_id: occurrence.reminder.id).count }
     end
 
+    # The before-due case was idempotent because the scheduled time anchored the
+    # target. After the due time the anchor was Time.current, so every retry
+    # computed a later target and created another occurrence.
+    it "is idempotent when a snooze is retried after the reminder was due" do
+      past = Occurrence.create!(reminder: occurrence.reminder, scheduled_at: 20.minutes.ago, status: :pending)
+
+      first = snooze!(past, minutes: 10)
+
+      expect {
+        second = snooze!(past, minutes: 10)
+        expect(second.id).to eq(first.id)
+      }.not_to change { Occurrence.where(reminder_id: occurrence.reminder.id).count }
+    end
+
+    it "does not stack up snooze acknowledgements on retry" do
+      past = Occurrence.create!(reminder: occurrence.reminder, scheduled_at: 20.minutes.ago, status: :pending)
+
+      snooze!(past, minutes: 10)
+
+      expect {
+        snooze!(past, minutes: 10)
+      }.not_to change { past.acknowledgements.where(kind: :snooze).count }
+    end
+
     it "does not leave an acknowledgement behind when the occurrence cannot be created" do
       future = Occurrence.create!(reminder: occurrence.reminder, scheduled_at: 25.minutes.from_now, status: :pending)
       allow(Occurrence).to receive(:find_or_create_by!).and_raise(ActiveRecord::RecordInvalid.new(Occurrence.new))

--- a/backend/spec/requests/acknowledgements_spec.rb
+++ b/backend/spec/requests/acknowledgements_spec.rb
@@ -186,6 +186,34 @@ RSpec.describe "Acknowledgements", type: :request do
       expect(new_occ.scheduled_at).to be_within(5.seconds).of(future.scheduled_at + 10.minutes)
     end
 
+    # The target time is deterministic now, so a retried request asks for exactly
+    # the same occurrence. Occurrences are unique on (reminder_id, scheduled_at),
+    # which would raise RecordNotUnique and return 500 for a snooze that had
+    # already succeeded.
+    it "is idempotent when the same snooze is retried" do
+      future = Occurrence.create!(reminder: occurrence.reminder, scheduled_at: 25.minutes.from_now, status: :pending)
+
+      first = snooze!(future, minutes: 10)
+      expect(response).to have_http_status(:created)
+
+      expect {
+        second = snooze!(future, minutes: 10)
+        expect(response).to have_http_status(:created)
+        expect(second.id).to eq(first.id)
+      }.not_to change { Occurrence.where(reminder_id: occurrence.reminder.id).count }
+    end
+
+    it "does not leave an acknowledgement behind when the occurrence cannot be created" do
+      future = Occurrence.create!(reminder: occurrence.reminder, scheduled_at: 25.minutes.from_now, status: :pending)
+      allow(Occurrence).to receive(:find_or_create_by!).and_raise(ActiveRecord::RecordInvalid.new(Occurrence.new))
+
+      expect {
+        post "/acknowledgements/snooze",
+          params: { occurrence_id: future.id, minutes: 10 },
+          headers: auth_headers
+      }.not_to change { Acknowledgement.count }
+    end
+
     it "uses the default delay when minutes cannot be parsed" do
       future = Occurrence.create!(reminder: occurrence.reminder, scheduled_at: 25.minutes.from_now, status: :pending)
 

--- a/backend/spec/requests/acknowledgements_spec.rb
+++ b/backend/spec/requests/acknowledgements_spec.rb
@@ -143,6 +143,47 @@ RSpec.describe "Acknowledgements", type: :request do
     end
   end
 
+  # The senior UI shows Snooze before the scheduled time, so this is reachable by
+  # tapping the button early — not an edge case.
+  describe "snoozing never moves a reminder earlier" do
+    def snooze!(occ, minutes: nil)
+      params = { occurrence_id: occ.id }
+      params[:minutes] = minutes unless minutes.nil?
+      post "/acknowledgements/snooze", params: params, headers: auth_headers
+      Occurrence.find(JSON.parse(response.body)["snoozed_occurrence_id"])
+    end
+
+    it "delays from the scheduled time when snoozed before it is due" do
+      future = Occurrence.create!(reminder: occurrence.reminder, scheduled_at: 25.minutes.from_now, status: :pending)
+
+      new_occ = snooze!(future, minutes: 10)
+
+      expect(new_occ.scheduled_at).to be_within(5.seconds).of(future.scheduled_at + 10.minutes)
+      expect(new_occ.scheduled_at).to be > future.scheduled_at
+    end
+
+    it "delays from now when snoozed after it is due" do
+      past = Occurrence.create!(reminder: occurrence.reminder, scheduled_at: 20.minutes.ago, status: :pending)
+
+      new_occ = snooze!(past, minutes: 10)
+
+      expect(new_occ.scheduled_at).to be_within(5.seconds).of(10.minutes.from_now)
+    end
+
+    it "does not accept a negative delay" do
+      new_occ = snooze!(occurrence, minutes: -30)
+      expect(new_occ.scheduled_at).to be > occurrence.scheduled_at
+    end
+
+    it "falls back to the default when minutes is missing or unparseable" do
+      future = Occurrence.create!(reminder: occurrence.reminder, scheduled_at: 25.minutes.from_now, status: :pending)
+
+      new_occ = snooze!(future, minutes: "not-a-number")
+
+      expect(new_occ.scheduled_at).to be > future.scheduled_at
+    end
+  end
+
   describe "POST /acknowledgements/snooze" do
     it "accepts a Bearer-authenticated snooze and schedules a new occurrence" do
       expect {

--- a/backend/spec/requests/acknowledgements_spec.rb
+++ b/backend/spec/requests/acknowledgements_spec.rb
@@ -175,12 +175,23 @@ RSpec.describe "Acknowledgements", type: :request do
       expect(new_occ.scheduled_at).to be > occurrence.scheduled_at
     end
 
-    it "falls back to the default when minutes is missing or unparseable" do
+    # Asserting the exact delay, not merely "later". A loose assertion passed while
+    # an unparseable value was silently clamping to one minute instead of using the
+    # default — the spec agreed with the bug.
+    it "uses the default delay when minutes is omitted" do
+      future = Occurrence.create!(reminder: occurrence.reminder, scheduled_at: 25.minutes.from_now, status: :pending)
+
+      new_occ = snooze!(future)
+
+      expect(new_occ.scheduled_at).to be_within(5.seconds).of(future.scheduled_at + 10.minutes)
+    end
+
+    it "uses the default delay when minutes cannot be parsed" do
       future = Occurrence.create!(reminder: occurrence.reminder, scheduled_at: 25.minutes.from_now, status: :pending)
 
       new_occ = snooze!(future, minutes: "not-a-number")
 
-      expect(new_occ.scheduled_at).to be > future.scheduled_at
+      expect(new_occ.scheduled_at).to be_within(5.seconds).of(future.scheduled_at + 10.minutes)
     end
   end
 


### PR DESCRIPTION
> Live bug on the senior path. Reachable by tapping a button that is visible before the reminder is due.

## The bug

`snooze` scheduled the replacement occurrence at `minutes.minutes.from_now`, ignoring when the reminder was actually due:

```ruby
scheduled_at: minutes.minutes.from_now
```

The senior UI shows **Snooze before the scheduled time**, so tapping it at 10:00 on a 10:25 reminder rescheduled it to **10:10 — fifteen minutes earlier** than it was already going to arrive. The original occurrence is acknowledged either way, so the earlier time is the only one left.

"Snooze" moving a medication reminder *closer* is the opposite of what the word means, and there is no way for a senior to notice it happened.

Spotted by @navjeetc while asking a UI question — whether Done and Snooze should appear before the reminder time. The answer turned out to matter for a reason beyond layout.

## The fix

Measure the delay from whichever is later, the scheduled time or now:

```ruby
base = [occ.scheduled_at, Time.current].max
scheduled_at: base + minutes.minutes
```

Before the due time this delays the original; after it, it delays from the moment the senior asked. Both read as "later" to the person tapping.

Also clamps `minutes`: a non-numeric or negative value became `0` or a negative offset via `to_i`, which is the same "moves earlier" failure by another route.

## Verification

Against the previous behaviour:

```
16 examples, 2 failures
  delays from the scheduled time when snoozed before it is due   FAILED
  falls back to the default when minutes is missing/unparseable  FAILED
```

With the fix: **129 examples, 0 failures**.

Specs cover snoozing before due, after due, a negative delay, and an unparseable value.

## Not included

Whether **Snooze** should be hidden until a reminder is due is a UI decision, still open. This fix makes the button safe whenever it is shown, which seemed the right order — the server should not depend on the client hiding a control to stay correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)