### PR TITLE
fix(web): hide Snooze until a reminder is due

### DIFF
--- a/backend/public/voice_reminders.js
+++ b/backend/public/voice_reminders.js
@@ -209,9 +209,23 @@ class VoiceRemindersApp {
         });
         
         const isCompleted = reminder.acknowledged_at;
-        const bgColor = isCompleted ? 'bg-green-50' : 'bg-yellow-50';
-        const borderColor = isCompleted ? 'border-green-300' : 'border-yellow-300';
-        
+        // A reminder that has not come due yet is not asking for anything, so it
+        // is shown plainly. The yellow highlight is reserved for "this is due
+        // now", which is what makes it worth noticing.
+        const isDue = scheduledDate <= new Date();
+
+        let bgColor, borderColor;
+        if (isCompleted) {
+            bgColor = 'bg-green-50';
+            borderColor = 'border-green-300';
+        } else if (isDue) {
+            bgColor = 'bg-yellow-50';
+            borderColor = 'border-yellow-300';
+        } else {
+            bgColor = 'bg-white';
+            borderColor = 'border-gray-200';
+        }
+
         return `
             <div class="p-6 rounded-xl border-4 ${borderColor} ${bgColor} shadow-lg">
                 <div class="flex justify-between items-start mb-4">
@@ -224,9 +238,11 @@ class VoiceRemindersApp {
                         <button id="ack-${reminder.id}" class="flex-1 inline-flex items-center justify-center px-6 py-4 border-2 border-transparent shadow-lg text-xl font-bold rounded-xl text-white bg-green-600 hover:bg-green-700 focus:ring-4 focus:ring-green-300" title="Mark as done">
                             ✓ Done
                         </button>
+                        ${isDue ? `
                         <button id="snooze-${reminder.id}" class="flex-1 inline-flex items-center justify-center px-6 py-4 border-2 border-gray-400 shadow-lg text-xl font-bold rounded-xl text-gray-800 bg-white hover:bg-gray-100 focus:ring-4 focus:ring-gray-300" title="Snooze for 10 minutes">
                             ⏰ Snooze
                         </button>
+                        ` : ''}
                     ` : `
                         <span class="inline-flex items-center px-6 py-4 text-2xl font-bold text-green-700">
                             ✓ Completed


### PR DESCRIPTION
Snoozing something that has not happened yet is incoherent — it means "remind me later" about a reminder that has not reminded you. Raised by @navjeetc while looking at a card an hour before its time.

## What changes

| | Before the due time | At/after the due time |
|---|---|---|
| Card | Plain white, grey border | **Yellow highlight** |
| Buttons | **Done only** | Done + Snooze |

**Done stays visible throughout.** Seniors take medication early, and letting them mark it prevents an announcement that has since become wrong. That option is worth more than the mild risk of a premature tap.

**The highlight now means something.** It was applied to every pending card regardless of time, so it read as "act now" for a reminder hours away and carried no information. Reserving it for actually-due reminders is the same reasoning as hiding Snooze.

The existing 10s poll re-renders, so both the highlight and the button appear on their own within ten seconds of the due time — no refresh needed.

## Relationship to #33

Complementary, not overlapping — different files, no conflict, either can merge first.

- **#33** makes Snooze *behave* correctly whenever it is shown: the delay is measured from `max(scheduled_at, now)`, so it can never move a reminder earlier.
- **This PR** removes the case where it is shown but meaningless.

I deliberately fixed the server first. The API should not depend on a client hiding a control in order to stay correct — anything else calling `/acknowledgements/snooze` would still have been able to reschedule a reminder earlier.

## Verification

Checked in a browser against a reminder 90 seconds out: card rendered plain with Done only, then highlighted and grew a Snooze button on its own once the time passed. Confirmed working by @navjeetc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)