### PR TITLE
feat(web): add a tap-to-start overlay when voice is locked

### DIFF
--- a/backend/public/voice_reminders.js
+++ b/backend/public/voice_reminders.js
@@ -7,7 +7,6 @@ class VoiceRemindersApp {
         this.synth = window.speechSynthesis;
         this.checkInterval = null;
         this.speechInitialized = false;
-        this.voiceUnlockPrompted = false;
         this.voiceUnlocked = this.hasPriorUserActivation();
         this.voiceUnlockListener = null;
         // Only surface the 🔊 prompt once speech has actually been refused, so
@@ -40,6 +39,7 @@ class VoiceRemindersApp {
         this.updateStatus('online');
         this.maybeShowVoiceUnlockPrompt();
         this.setupVoiceUnlockListeners();
+        this.showTapToStart();
     }
     
     initializeSpeech() {
@@ -518,9 +518,9 @@ class VoiceRemindersApp {
             try {
                 await this.performVoiceUnlockSequence();
                 this.voiceUnlocked = true;
-                this.voiceUnlockPrompted = false;
                 this.voiceBlocked = false;
                 this.hideBanner();
+                this.hideTapToStart();
                 if (!silent) this.showBanner('Voice announcements enabled', { autoHideMs: 3000 });
                 this.removeVoiceUnlockListeners();
                 this.replayPendingVoiceAnnouncements();
@@ -576,6 +576,67 @@ class VoiceRemindersApp {
         button.style.display = needsPrompt ? 'inline-flex' : 'none';
     }
 
+    // A page that cannot speak looks identical to one that has nothing to say.
+    // The small 🔊 button was not enough: an iPad that reloads itself in the
+    // background goes silent, and nobody watching it would know why. This makes
+    // the requirement impossible to miss and impossible to ignore, because the
+    // page is not usable until it is dismissed.
+    //
+    // Only shown when voice is genuinely locked, so anyone who arrived by
+    // clicking a link — which already counts as the gesture — never sees it.
+    showTapToStart() {
+        if (!this.synth) return;              // nothing to unlock
+        if (this.voiceUnlocked) return;
+        if (document.getElementById("tapToStart")) return;
+
+        const overlay = document.createElement("div");
+        overlay.id = "tapToStart";
+        overlay.setAttribute("role", "dialog");
+        overlay.setAttribute("aria-modal", "true");
+        overlay.setAttribute("aria-labelledby", "tapToStartHeading");
+        overlay.style.cssText =
+            "position:fixed;inset:0;z-index:10000;display:flex;align-items:center;" +
+            "justify-content:center;background:#1e3a8a;color:#fff;text-align:center;padding:2rem;cursor:pointer";
+
+        overlay.innerHTML =
+            '<div style="max-width:34rem">' +
+              '<h2 id="tapToStartHeading" style="font-size:2.5rem;line-height:1.15;font-weight:800;margin:0 0 1rem">Tap to start</h2>' +
+              '<p style="font-size:1.5rem;line-height:1.4;margin:0 0 2rem">' +
+                "Your browser needs one tap before Remindly can speak reminders out loud." +
+              "</p>" +
+              '<button type="button" id="tapToStartButton" style="font-size:1.5rem;font-weight:700;padding:1rem 2.5rem;' +
+                'border-radius:0.75rem;border:0;background:#fff;color:#1e3a8a;cursor:pointer">Turn on voice</button>' +
+              '<p id="tapToStartError" style="font-size:1.125rem;margin:1.5rem 0 0;display:none"></p>' +
+            "</div>";
+
+        // The whole surface responds, so a senior does not have to find the
+        // button — but the button is real, for keyboard and screen reader users.
+        const unlock = async (event) => {
+            event.preventDefault();
+            const ok = await this.handleVoiceUnlock({ silent: true });
+
+            if (ok) {
+                this.hideTapToStart();
+            } else {
+                const error = document.getElementById("tapToStartError");
+                if (error) {
+                    error.textContent = "That did not work. Please tap again.";
+                    error.style.display = "block";
+                }
+            }
+        };
+
+        overlay.addEventListener("click", unlock);
+        overlay.addEventListener("touchend", unlock, { passive: false });
+
+        document.body.appendChild(overlay);
+        document.getElementById("tapToStartButton")?.focus();
+    }
+
+    hideTapToStart() {
+        document.getElementById("tapToStart")?.remove();
+    }
+
     // Every modern browser gates speechSynthesis behind a user gesture, not just
     // iOS — Chrome's autoplay policy rejects speak() with 'not-allowed' on a page
     // the user has never interacted with. A senior's browser left open on a desk,
@@ -605,10 +666,9 @@ class VoiceRemindersApp {
         }
         this.setupVoiceUnlockListeners();
         this.maybeShowVoiceUnlockPrompt();
-        if (!this.voiceUnlockPrompted) {
-            this.showBanner('Tap anywhere to enable voice announcements');
-            this.voiceUnlockPrompted = true;
-        }
+        // Speech was refused, so voice is locked again — put the overlay back
+        // rather than relying on a banner the reader has to notice.
+        this.showTapToStart();
     }
 
     // Speak anything refused while voice was locked, driven by the unlock rather

--- a/backend/public/voice_reminders.js
+++ b/backend/public/voice_reminders.js
@@ -586,6 +586,15 @@ class VoiceRemindersApp {
     // clicking a link — which already counts as the gesture — never sees it.
     showTapToStart() {
         if (!this.synth) return;              // nothing to unlock
+        // Someone who turned voice announcements off in settings should not be
+        // met by a full-screen demand to turn them on. speak() already returns
+        // early for them, so there is nothing to unlock either.
+        //
+        // Explicitly false, not merely falsy: loadSettings returns whatever is in
+        // localStorage, so a stored object written before this key existed would
+        // read as undefined and suppress the overlay for someone who never chose
+        // to turn voice off.
+        if (this.settings.voiceEnabled === false) return;
         if (this.voiceUnlocked) return;
         if (document.getElementById("tapToStart")) return;
 
@@ -606,7 +615,7 @@ class VoiceRemindersApp {
               "</p>" +
               '<button type="button" id="tapToStartButton" style="font-size:1.5rem;font-weight:700;padding:1rem 2.5rem;' +
                 'border-radius:0.75rem;border:0;background:#fff;color:#1e3a8a;cursor:pointer">Turn on voice</button>' +
-              '<p id="tapToStartError" style="font-size:1.125rem;margin:1.5rem 0 0;display:none"></p>' +
+              '<p id="tapToStartError" role="status" aria-live="assertive" style="font-size:1.125rem;margin:1.5rem 0 0;display:none"></p>' +
             "</div>";
 
         // The whole surface responds, so a senior does not have to find the
@@ -628,6 +637,17 @@ class VoiceRemindersApp {
 
         overlay.addEventListener("click", unlock);
         overlay.addEventListener("touchend", unlock, { passive: false });
+
+        // aria-modal tells assistive tech the rest of the page is inert, but it
+        // does not stop Tab reaching it. Without this a keyboard user tabs to
+        // controls they cannot see behind the overlay and loses the focus ring.
+        // The overlay holds one control, so keeping focus on it is the whole trap.
+        overlay.addEventListener("keydown", (event) => {
+            if (event.key === "Tab") {
+                event.preventDefault();
+                document.getElementById("tapToStartButton")?.focus();
+            }
+        });
 
         document.body.appendChild(overlay);
         document.getElementById("tapToStartButton")?.focus();


### PR DESCRIPTION
A page that cannot speak looks exactly like one with nothing to say.

Browsers refuse `speechSynthesis` until the user has interacted with the page, and on iOS that applies after **every** load — including the reloads iOS performs on its own when it discards and restores a background tab. An iPad on a kitchen counter can go quiet, and nobody watching it would know why.

## What changes

A full-screen overlay when voice is locked:

> **Tap to start**
> Your browser needs one tap before Remindly can speak reminders out loud.
> [ Turn on voice ]

The 🔊 button that existed before was small, easy to miss, and only explained itself to someone already looking for it.

**It blocks the page, deliberately.** A reminder you can read but that cannot be spoken is the failure this exists to fix, so the page is not usable until it is dismissed.

## When it appears

Only when voice is genuinely locked:

| | Behaviour |
|---|---|
| **Desktop** | Effectively never — every route to the page involves a click, which grants activation |
| **iOS** | Always, on every load. WebKit wants speech initiated *from* the gesture, not merely after one |

## Accessibility

The whole surface responds to a tap so nobody has to find a target, but there is a real focusable button for keyboard and screen-reader users, and the overlay carries `role="dialog"` with a labelled heading and receives focus on open. A failed unlock keeps the overlay up and asks for another tap rather than dropping the visitor onto a silent page.

## Also removes `voiceUnlockPrompted`

Now dead state. It was the latch that showed the warning **once per page load**, so a senior who missed it got no second chance — a gap flagged earlier in the day. The overlay replaces it by persisting until dismissed.

## Verification

Tested on a real iPhone, since desktop cannot exercise it:

1. Overlay appeared on load, before any interaction
2. One tap anywhere dismissed it
3. The reminder spoke
4. It did not return

Desktop was checked too and correctly showed nothing — `navigator.userActivation.hasBeenActive` is already true after a link click.

**158 examples, 0 failures.** RuboCop and Brakeman both exit 0.

## Open question

The frequency. On iOS this appears on every page load, including system-initiated reloads. My view is that a tap nobody wanted beats a reminder nobody hears, but that is a judgement about how these devices are actually used. The alternatives are a non-blocking banner (less intrusive, easier to miss) or blocking only when a reminder is due (out of the way, but the tap then arrives at the worst possible moment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)