### PR TITLE
feat(web): lead the homepage with the caregiver's situation

### DIFF
--- a/backend/app/views/pages/home.html.erb
+++ b/backend/app/views/pages/home.html.erb
@@ -18,12 +18,13 @@
 
 <p>
   A tablet or computer sits somewhere they already spend time — the kitchen
-  table, beside a favourite chair. When a reminder is due, it speaks:
+  table, beside a favourite chair — with Remindly open on the screen, the way a
+  clock sits on a shelf. When a reminder is due, it speaks:
   <em>"Take your morning medication."</em>
 </p>
 
 <p>
-  The screen shows one reminder at a time, in large type, with two buttons:
+  The screen lists the day's reminders in large type, each with two buttons:
   <strong>Done</strong> and <strong>Snooze</strong>. Nothing to install, no
   password to remember, no menus to get lost in.
 </p>
@@ -36,8 +37,8 @@
     after lunch — from your own phone or computer, wherever you happen to be.
   </li>
   <li>
-    <strong>They hear them at home</strong>, spoken aloud, without needing to
-    check anything.
+    <strong>They hear them at home</strong>, spoken aloud, without having to read
+    a screen or open an app.
   </li>
   <li>
     <strong>You can see what was done</strong> and what was missed, so checking in
@@ -47,10 +48,17 @@
 
 <div class="note">
   <p>
-    <strong>One thing worth knowing:</strong> browsers will not play sound until
-    someone has touched the screen, so on an iPad Remindly asks for a single tap
-    after it starts up. It remembers anything it could not say and speaks it once
-    you do.
+    <strong>Two things worth knowing before you set this up.</strong>
+  </p>
+  <p>
+    Remindly speaks through the page, so that page needs to stay open on their
+    device — think of it as leaving a clock on the counter rather than an app you
+    open when you need it. Close the tab and nothing is spoken.
+  </p>
+  <p>
+    And browsers will not play sound until someone has touched the screen, so on
+    an iPad Remindly asks for a single tap after it starts up. It remembers
+    anything it could not say and speaks it once you do.
   </p>
 </div>
 

--- a/backend/app/views/pages/home.html.erb
+++ b/backend/app/views/pages/home.html.erb
@@ -1,12 +1,12 @@
-<% content_for :title, "Remindly — spoken reminders for seniors, set up by the people who care for them" %>
-<% content_for :description, "Remindly speaks reminders aloud at the right time, so a senior does not have to read a screen or open an app. Caregivers set them up from anywhere and can see what has been done." %>
+<% content_for :title, "Remindly — spoken reminders for a parent living on their own" %>
+<% content_for :description, "Remindly says reminders out loud at the right time, so a parent living on their own does not have to read a screen or open an app. You set them up from wherever you are, and can see what has been done without phoning to ask." %>
 
-<h1>Reminders that speak up</h1>
+<h1>Caring for a parent from a distance</h1>
 
 <p class="lead">
-  Remindly says reminders out loud at the right time — take your medication,
-  drink some water, the nurse comes today — so nobody has to remember to check a
-  screen.
+  You cannot be there for every tablet, every appointment, every glass of water.
+  Remindly says each reminder out loud at the right time, so the person you care
+  for hears it — and you can see it was done without having to ring and ask.
 </p>
 
 <div class="actions">
@@ -14,42 +14,43 @@
   <a class="btn btn-secondary" href="<%= how_to_path %>">See how it works</a>
 </div>
 
-<h2>How it works</h2>
+<h2>What it looks like at their end</h2>
+
+<p>
+  A tablet or computer sits somewhere they already spend time — the kitchen
+  table, beside a favourite chair. When a reminder is due, it speaks:
+  <em>"Take your morning medication."</em>
+</p>
+
+<p>
+  The screen shows one reminder at a time, in large type, with two buttons:
+  <strong>Done</strong> and <strong>Snooze</strong>. Nothing to install, no
+  password to remember, no menus to get lost in.
+</p>
+
+<h2>What it looks like at yours</h2>
 
 <ol class="steps">
   <li>
-    <strong>A caregiver sets up the reminders.</strong> From their own phone or
-    computer, wherever they are.
+    <strong>You set the reminders up</strong> — medication, appointments, a walk
+    after lunch — from your own phone or computer, wherever you happen to be.
   </li>
   <li>
-    <strong>The senior leaves the page open.</strong> On a tablet or computer,
-    usually somewhere they already spend time.
+    <strong>They hear them at home</strong>, spoken aloud, without needing to
+    check anything.
   </li>
   <li>
-    <strong>Remindly speaks each reminder when it is due</strong>, and they tap
-    one large button to say it is done — or snooze it.
+    <strong>You can see what was done</strong> and what was missed, so checking in
+    does not have to mean another phone call asking whether they remembered.
   </li>
 </ol>
 
-<h2>Built for the person using it</h2>
-
-<p>
-  The reminder screen is deliberately plain: large text, two buttons, no menus to
-  get lost in. There is nothing to install and no password to remember — signing
-  in is a link sent by email.
-</p>
-
-<p>
-  Caregivers get their own view showing what was acknowledged and what was
-  missed, so checking in does not mean a phone call every time.
-</p>
-
 <div class="note">
   <p>
-    <strong>One thing worth knowing:</strong> browsers will not play audio until
-    someone has touched the page, so on an iPad the screen needs a single tap
-    after it loads before reminders can be spoken aloud. Remindly asks for that
-    tap and remembers anything it could not say, then speaks it once you do.
+    <strong>One thing worth knowing:</strong> browsers will not play sound until
+    someone has touched the screen, so on an iPad Remindly asks for a single tap
+    after it starts up. It remembers anything it could not say and speaks it once
+    you do.
   </p>
 </div>
 

--- a/backend/spec/requests/pages_spec.rb
+++ b/backend/spec/requests/pages_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe "Pages", type: :request do
         get "/"
 
         expect(response).to have_http_status(:ok)
-        expect(doc.at_css("h1").text).to include("Reminders that speak up")
+        expect(doc.at_css("h1").text).to include("Caring for a parent")
       end
 
       # The site previously had no indexable homepage at all: / was


### PR DESCRIPTION
The page opened with "Reminders that speak up" and then explained the mechanism. That describes what the software does rather than why anyone would want it — and the person reading is usually worrying about a parent living alone, not shopping for a reminder feature.

## Where this came from

@navjeetc wrote a video script for the product that is far better at this than my copy was. It opens on the difficulty of caring from a distance, shows the tablet speaking in the kitchen, and ends on the relief of knowing.

The page now follows the same arc:

| | |
|---|---|
| **H1** | "Caring for a parent from a distance" *(was: "Reminders that speak up")* |
| **What it looks like at their end** | A tablet by a favourite chair, speaking *"Take your morning medication."* Large type, two buttons |
| **What it looks like at yours** | Set reminders from anywhere; see what was done, so checking in is not another phone call |

## One beat is deliberately different

The script has the caregiver receiving a notification: **"Mom completed her medication."**

**No such notification exists.** Notifications fire for task assignments and coverage gaps only — I checked before writing. The page says *"you can see what was done"* instead, which is true, because the dashboard shows acknowledgements.

Writing the stronger version would have put a claim on the homepage the product does not honour — the same failure as the docs that described the wrong client as the senior interface and cost a day earlier. It is worth building, and @navjeetc has queued it; until then the page says what is so.

That gap is also the clearest argument for building it: "you can look and see" is a weaker promise than "you will be told", and the difference is exactly the reassurance a caregiver is after.

## Kept

The iOS tap caveat and the pending-approval explanation. Both are unpleasant surprises if discovered after setting Remindly up for a relative.

## Verification

**158 examples, 0 failures.** RuboCop and Brakeman exit 0. The existing homepage specs still hold — no third-party assets, no session cookie for anonymous visitors, canonical URL, links to `/how_to` and `/login` — with the heading assertion updated.

Reviewed in a browser by @navjeetc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)